### PR TITLE
FIX: move hardcoded address to application.properties

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,6 @@ build: mvn-build docker-build
 
 up:
 	docker-compose up
+
+down:
+	docker-compose down

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -78,7 +78,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>

--- a/api/src/main/java/com/codecool/quokka/controller/AssetController.java
+++ b/api/src/main/java/com/codecool/quokka/controller/AssetController.java
@@ -9,6 +9,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.client.RestTemplate;
 
@@ -16,11 +18,13 @@ import java.util.*;
 
 @RequestMapping("/api/v1/asset")
 @RestController
+@ConfigurationProperties
 public class AssetController {
     private RestTemplate restTemplate = new RestTemplate();
     private ObjectMapper mapper = new ObjectMapper();
 
-    private String url = "http://assetcache:8000/api/v1/";
+    @Value("${quokka.service.assetcache.address}${quokka.service.assetcache.endpoint}")
+    private String url;
     @GetMapping( "{type}")
     public List<String> getAssets(@PathVariable("type") String type) throws JsonProcessingException {
         String newUrl = url + type;

--- a/api/src/main/java/com/codecool/quokka/controller/FinController.java
+++ b/api/src/main/java/com/codecool/quokka/controller/FinController.java
@@ -3,6 +3,8 @@ package com.codecool.quokka.controller;
 import com.codecool.quokka.model.OrderDto;
 import com.codecool.quokka.model.assets.AssetType;
 import com.codecool.quokka.model.order.Orders;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,10 +17,13 @@ import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/v1/order")
+@ConfigurationProperties
 public class FinController {
     public static final UUID ACCOUNT_ID = UUID.fromString("a1521309-f533-460a-a9fc-3028b0efc79b");
     private RestTemplate restTemplate = new RestTemplate();
-    private String url = "http://oms:9000/api/v1/order";
+
+    @Value("${quokka.service.oms.address}${quokka.service.oms.endpoint}")
+    private String url;
 
     @PostMapping(path = "stock")
     public ResponseEntity createNewStockOrder(@RequestBody OrderDto data) {

--- a/api/src/main/resources/application-dev.properties
+++ b/api/src/main/resources/application-dev.properties
@@ -1,12 +1,20 @@
-##connect to database
+# database connection details
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.datasource.url=jdbc:postgresql://localhost:5433/quokka
 spring.datasource.username=postgres
 spring.datasource.password=asdqwe
 
-
+# JPA details
 spring.jpa.database-platform = org.hibernate.dialect.PostgreSQL94Dialect
 spring.jpa.show-sql = false
 spring.jpa.hibernate.ddl-auto = update
 spring.jpa.hibernate.naming.implicit-strategy = org.hibernate.boot.model.naming.ImplicitNamingStrategyJpaCompliantImpl
 spring.jpa.properties.hibernate.format_sql=true
+
+# asset cache address
+quokka.service.assetcache.address = http://localhost:8000
+quokka.service.assetcache.endpoint = /api/v1/
+
+# oms address
+quokka.service.oms.address = http://localhost:9000
+quokka.service.oms.endpoint = /api/v1/order

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -1,10 +1,10 @@
-##connect to database
+# database connection details
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.datasource.url=jdbc:postgresql://postgres:5432/quokka
 spring.datasource.username=postgres
 spring.datasource.password=asdqwe
 
-
+# JPA details
 spring.jpa.database-platform = org.hibernate.dialect.PostgreSQL94Dialect
 spring.jpa.show-sql = false
 spring.jpa.hibernate.ddl-auto = update
@@ -12,3 +12,11 @@ spring.h2.console.enabled = true
 spring.h2.console.path=/h2-console
 spring.jpa.hibernate.naming.implicit-strategy = org.hibernate.boot.model.naming.ImplicitNamingStrategyJpaCompliantImpl
 spring.jpa.properties.hibernate.format_sql=true
+
+# asset cache address
+quokka.service.assetcache.address = http://assetcache:8000
+quokka.service.assetcache.endpoint = /api/v1/
+
+# oms address
+quokka.service.oms.address = http://oms:9000
+quokka.service.oms.endpoint = /api/v1/order

--- a/oms/pom.xml
+++ b/oms/pom.xml
@@ -25,6 +25,11 @@
             <version>2.7.3</version>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>

--- a/oms/src/main/resources/application-dev.properties
+++ b/oms/src/main/resources/application-dev.properties
@@ -1,10 +1,11 @@
 server.port=9000
+# database connection details
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.datasource.url=jdbc:postgresql://localhost:5433/quokka
 spring.datasource.username=postgres
 spring.datasource.password=asdqwe
 
-
+# JPA details
 spring.jpa.database-platform = org.hibernate.dialect.PostgreSQL94Dialect
 spring.jpa.show-sql = false
 spring.jpa.hibernate.ddl-auto = update
@@ -12,3 +13,7 @@ spring.jpa.hibernate.naming.implicit-strategy = org.hibernate.boot.model.naming.
 spring.jpa.properties.hibernate.format_sql=true
 
 spring.rabbitmq.addresses = localhost:5672
+
+# asset cache address
+quokka.service.assetcache.address = http://localhost:8000
+quokka.service.assetcache.endpoint = /api/v1/

--- a/oms/src/main/resources/application.properties
+++ b/oms/src/main/resources/application.properties
@@ -1,10 +1,12 @@
 server.port=9000
+
+# database connection details
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.datasource.url=jdbc:postgresql://postgres:5432/quokka
 spring.datasource.username=postgres
 spring.datasource.password=asdqwe
 
-
+# JPA details
 spring.jpa.database-platform = org.hibernate.dialect.PostgreSQL94Dialect
 spring.jpa.show-sql = false
 spring.jpa.hibernate.ddl-auto = update
@@ -12,3 +14,7 @@ spring.jpa.hibernate.naming.implicit-strategy = org.hibernate.boot.model.naming.
 spring.jpa.properties.hibernate.format_sql=true
 
 spring.rabbitmq.addresses = rabbitmq:5672
+
+# asset cache address
+quokka.service.assetcache.address = http://assetcache:8000
+quokka.service.assetcache.endpoint = /api/v1/


### PR DESCRIPTION
moves the hardcoded component addresses to prop files, which also make it possible to run the components in the local developer environment, with the DEV profile, with eg.: 
```
-Dspring.profiles.active=dev
```